### PR TITLE
Use `@153-less-restrictive-projections` for ci.yml, remove `includes`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   pr-ci:
     name: CI
     if: github.event_name == 'pull_request' && github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@main
+    uses: access-nri/build-cd/.github/workflows/ci.yml@153-less-restrictive-projections
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,7 +4,7 @@
 # configuration settings.
 spack:
   specs:
-    - access-test@git.2024.09.20
+    - access-test@git.2024.09.21
   packages:
     oasis3-mct:
       require:
@@ -35,11 +35,10 @@ spack:
         tcl: $spack/../release/modules
         lmod: $spack/../release/lmod
       tcl:
-        hash_length: 0
+        # hash_length: 0
         include:
           # Explicitly, which packages are accessible as modules
           - access-test
-          - oasis3-mct
         exclude_implicits: true
         all:
           autoload: run
@@ -50,5 +49,4 @@ spack:
               'SPACK_{name}_ROOT': '{prefix}'
         projections:
           all: '{name}/{version}'
-          access-test: '{name}/2024.09.20'
-          oasis3-mct: '{name}/2023.11.09'
+          access-test: '{name}/2024.09.21'

--- a/spack.yaml
+++ b/spack.yaml
@@ -50,4 +50,4 @@ spack:
         projections:
           all: '{name}/{version}'
           access-test: '{name}/2024.09.21'
-          oasis3-mct: '{name}/9999.99.99'  # This should fail
+          oasis3-mct: '{name}/2023.11.09'  # This should succeed

--- a/spack.yaml
+++ b/spack.yaml
@@ -50,3 +50,4 @@ spack:
         projections:
           all: '{name}/{version}'
           access-test: '{name}/2024.09.21'
+          oasis3-mct: '{name}/9999.99.99'  # This should fail


### PR DESCRIPTION
Testing out the PR ACCESS-NRI/build-cd#154 via issue ACCESS-NRI/build-cd#153. 

Attempting deployments with `oasis3-mct`:
- [x] using no projection (the default spack modules).  See https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/11586369724/job/32256919683
- [x] using a custom correct projection. See https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/11586481770/job/32257152306
- [x] using a custom incorrect projection. Task failed successfully :tm: https://github.com/ACCESS-NRI/ACCESS-TEST/actions/runs/11586453093/job/32257067138?pr=1
