### PR TITLE
TEST: Updated Release Environment Name

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@
 spack:
   definitions:
     - ROOT_PACKAGE:
-        - access-test@git.2025.01.0
+        - access-test@git.2025.01.1
 
     # Specific case for Gadi - should be run
     - when: env['DEPLOYMENT_TARGET'] == 'gadi'
@@ -53,5 +53,5 @@ spack:
           - access-test
           - oasis3-mct
         projections:
-          access-test: '{name}/2025.01.0'
+          access-test: '{name}/2025.01.1'
           oasis3-mct: '{name}/2023.11.09-{hash:7}'


### PR DESCRIPTION
A test for ACCESS-NRI/build-cd#221 with updated release GitHub Environments of the form `SUPERCOMPUTER Release`. 


---
:rocket: The latest prerelease `access-test/pr22-1` at 3be637ec60d6bbaa313a7f6e7a7f60c49169df83 is here: https://github.com/ACCESS-NRI/ACCESS-TEST/pull/22#issuecomment-2629879830 :rocket:
