### PR TITLE
TEST: Relaxed Specs and Action-ifying common `yq` ops

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@
 spack:
   definitions:
     - ROOT_PACKAGE:
-        - access-test@git.2025.02.0=access-test
+        - access-test@git.2025.02.0
 
     # Specific case for Gadi - should be run
     - when: env['DEPLOYMENT_TARGET'] == 'gadi'

--- a/spack.yaml
+++ b/spack.yaml
@@ -2,28 +2,29 @@
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.
-# This is testing of the dev-121-multi-target-workflows branch!!!
+# This is testing of the 226-relax-specs branch!
 spack:
-  definitions:
-    - ROOT_PACKAGE:
-        - access-test@git.2025.01.1
+  # definitions:
+  #   - ROOT_PACKAGE:
+  #       - access-test@git.2025.01.1=access-test
 
-    # Specific case for Gadi - should be run
-    - when: env['DEPLOYMENT_TARGET'] == 'gadi'
-      compiler_targets:
-        - intel@2021.10.0 target=x86_64
+  #   # Specific case for Gadi - should be run
+  #   - when: env['DEPLOYMENT_TARGET'] == 'gadi'
+  #     compiler_targets:
+  #       - intel@2021.10.0 target=x86_64
 
-    # Default case, shouldn't be used
-    - when: '"DEPLOYMENT_TARGET" not in env'
-      compiler_targets:
-        - gcc@11.2.0 target=x86_64
+  #   # Default case, shouldn't be used
+  #   - when: '"DEPLOYMENT_TARGET" not in env'
+  #     compiler_targets:
+  #       - gcc@11.2.0 target=x86_64
 
-    - ROOT_SPEC:
-      - matrix:
-          - [$ROOT_PACKAGE]
-          - [$%compiler_targets]
+  #   - ROOT_SPEC:
+  #     - matrix:
+  #         - [$ROOT_PACKAGE]
+  #         - [$%compiler_targets]
   specs:
-    - $ROOT_SPEC
+    # - $ROOT_SPEC
+    - access-test@git.2025.01.1=access-test
   packages:
     oasis3-mct:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -2,7 +2,7 @@
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.
-# This is testing of the 226-relax-specs branch!
+# This is testing of the 226-relax-specs branch!!
 spack:
   # definitions:
   #   - ROOT_PACKAGE:

--- a/spack.yaml
+++ b/spack.yaml
@@ -24,7 +24,7 @@ spack:
   #         - [$%compiler_targets]
   specs:
     # - $ROOT_SPEC
-    - access-test@git.2025.01.1=access-test
+    - access-test@git.2025.02.0=access-test
   packages:
     oasis3-mct:
       require:
@@ -39,11 +39,11 @@ spack:
       require:
         - '@4.1.5'
         - 'cppflags="-diag-disable=10441"'
-    # Specifications that apply to all packages - not relevant with multi-target builds
-    # all:
-    #   require:
-    #     - '%intel@2021.10.0'
-    #     - 'target=x86_64'
+        # Specifications that apply to all packages - not relevant with multi-target builds
+        # all:
+        #   require:
+        #     - '%intel@2021.10.0'
+        #     - 'target=x86_64'
   view: true
   concretizer:
     unify: true
@@ -54,5 +54,5 @@ spack:
           - access-test
           - oasis3-mct
         projections:
-          access-test: '{name}/2025.01.1'
+          access-test: '{name}/2025.02.0'
           oasis3-mct: '{name}/2023.11.09-{hash:7}'

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,27 +4,27 @@
 # configuration settings.
 # This is testing of the 226-relax-specs branch!!
 spack:
-  # definitions:
-  #   - ROOT_PACKAGE:
-  #       - access-test@git.2025.01.1=access-test
+  definitions:
+    - ROOT_PACKAGE:
+        - access-test@git.2025.02.0=access-test
 
-  #   # Specific case for Gadi - should be run
-  #   - when: env['DEPLOYMENT_TARGET'] == 'gadi'
-  #     compiler_targets:
-  #       - intel@2021.10.0 target=x86_64
+    # Specific case for Gadi - should be run
+    - when: env['DEPLOYMENT_TARGET'] == 'gadi'
+      compiler_targets:
+        - intel@2021.10.0 target=x86_64
 
-  #   # Default case, shouldn't be used
-  #   - when: '"DEPLOYMENT_TARGET" not in env'
-  #     compiler_targets:
-  #       - gcc@11.2.0 target=x86_64
+    # Default case, shouldn't be used
+    - when: '"DEPLOYMENT_TARGET" not in env'
+      compiler_targets:
+        - gcc@11.2.0 target=x86_64
 
-  #   - ROOT_SPEC:
-  #     - matrix:
-  #         - [$ROOT_PACKAGE]
-  #         - [$%compiler_targets]
+    - ROOT_SPEC:
+      - matrix:
+          - [$ROOT_PACKAGE]
+          - [$%compiler_targets]
   specs:
-    # - $ROOT_SPEC
-    - access-test@git.2025.02.0=access-test
+    - $ROOT_SPEC
+    # - access-test@git.2025.02.0=access-test
   packages:
     oasis3-mct:
       require:


### PR DESCRIPTION
References ACCESS-NRI/build-cd#226.

Testing out `get-spack-root-specs` action, which replaces `env.SPACK_YAML_MODEL_YQ` in all pipelines.



---
:rocket: The latest prerelease `access-test/pr25-6` at 001c691bd8f63325a476e7138235d9652d889e24 is here: https://github.com/ACCESS-NRI/ACCESS-TEST/pull/25#issuecomment-2652679687 :rocket:















