### PR TITLE
Comment out existing multi-HPC version of the workflow

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -25,10 +25,10 @@ spack:
   #         - [$%compiler_targets]
   specs:
     # - $ROOT_SPEC
-    - access-test@git.2025.03.1
+    - access-test@git.2025.04.0=null
   packages:
     access-test-component:
-     require:
+      require:
         - '@main'
     openmpi:
       require:
@@ -51,4 +51,4 @@ spack:
           - access-test
           - access-test-component
         projections:
-          access-test: '{name}/2025.03.1'
+          access-test: '{name}/2025.04.0'

--- a/spack.yaml
+++ b/spack.yaml
@@ -2,27 +2,30 @@
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.
-# This is testing of the dev-121-multi-target-workflows branch!!!
 spack:
-  definitions:
-    - ROOT_PACKAGE:
-        - access-test@git.2025.03.1
-    # Specific case for Gadi - should be run
-    - when: env['DEPLOYMENT_TARGET'] == 'gadi'
-      compiler_targets:
-        - intel@2021.10.0 target=x86_64
+  ## This section is what would be done for multi-HPC builds - see the commented reference to
+  ## $ROOT_SPEC in spack.specs below.
+  # definitions:
+  #   - ROOT_PACKAGE:
+  #       - access-test@git.2025.03.1
+  #
+  #   # Specific case for Gadi - should be run. Note the check for the environment variable first!
+  #   - when: '"DEPLOYMENT_TARGET" in env and env["DEPLOYMENT_TARGET"] == "gadi"'
+  #     compiler_targets:
+  #       - intel@2021.10.0 target=x86_64
+  #
+  #   # Example default case, should only be used outside of the CI system.
+  #   - when: '"DEPLOYMENT_TARGET" not in env'
+  #     compiler_targets:
+  #       - intel@2021.10.0 target=x86_64
 
-    # Default case, shouldn't be used
-    - when: '"DEPLOYMENT_TARGET" not in env'
-      compiler_targets:
-        - gcc@11.2.0 target=x86_64
-
-    - ROOT_SPEC:
-      - matrix:
-          - [$ROOT_PACKAGE]
-          - [$%compiler_targets]
+  #   - ROOT_SPEC:
+  #     - matrix:
+  #         - [$ROOT_PACKAGE]
+  #         - [$%compiler_targets]
   specs:
-    - $ROOT_SPEC
+    # - $ROOT_SPEC
+    - access-test@git.2025.03.1
   packages:
     access-test-component:
      require:
@@ -33,6 +36,11 @@ spack:
     gcc-runtime:
       require:
         - '%gcc'
+    # When using multi-HPC builds, this spack.packages.all section can be commented out.
+    all:
+      require:
+        - '%intel@2021.10.0'
+        - 'target=x86_64'
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
   #         - [$%compiler_targets]
   specs:
     # - $ROOT_SPEC
-    - access-test@git.2025.04.0=null
+    - access-test@git.2025.04.000
   packages:
     access-test-component:
       require:
@@ -51,4 +51,4 @@ spack:
           - access-test
           - access-test-component
         projections:
-          access-test: '{name}/2025.04.0'
+          access-test: '{name}/2025.04.000'


### PR DESCRIPTION
See https://github.com/ACCESS-NRI/ACCESS-TEST/issues/28
Closes #14

## Background

Users attempting to install the `spack.yaml` in this repository (outside of the CI) are getting errors about `env.DEPLOYMENT_TARGET` not being defined. 

This is because the conditional that checks for `env.DEPLOYMENT_TARGET` still runs, and users who don't have that environment variable are getting errors. 

The fix for this is for the `when` clause to check whether the variable exists before checking for equality (eg. `when: '"DEPLOYMENT_TARGET" in env  and env["DEPLOYMENT_TARGET"] == "gadi"'`). But an easier solution is to just use the simpler version of the manifest (the non-multi-HPC one). 

## The PR

* Comment out the multi-HPC stuff
* Use the regular, simpler non-multi-HPC format


---
:rocket: The latest prerelease `access-test/pr35-1` at 7bcdb6aaf8eff2a06de920184256d70497aa6c4a is here: https://github.com/ACCESS-NRI/ACCESS-TEST/pull/35#issuecomment-2777222735 :rocket:



---
:rocket: The latest prerelease `access-test/pr35-2` at 4fb065a9f955cfb7fb94ed2b7df81296bd62797d is here: https://github.com/ACCESS-NRI/ACCESS-TEST/pull/35#issuecomment-2777333416 :rocket:
