### PR TITLE
Test: Release Provenance DB 2.0

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v4
+    uses: access-nri/build-cd/.github/workflows/cd.yml@263-release-provenance-2.0_TEST
     with:
       model: ${{ vars.NAME }}
     permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     name: CI
     if: >-
       (github.event_name == 'pull_request' && github.event.action != 'closed') || (github.event_name == 'issue_comment' && startsWith(github.event.comment.body, '!redeploy'))
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v4
+    uses: access-nri/build-cd/.github/workflows/ci.yml@263-release-provenance-2.0_TEST
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
@@ -36,7 +36,7 @@ jobs:
   pr-comment:
     name: Comment
     if: github.event_name == 'issue_comment'
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v4
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@263-release-provenance-2.0_TEST
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
@@ -47,7 +47,7 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event_name == 'pull_request' && github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v4
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@263-release-provenance-2.0_TEST
     with:
       root-sbd: access-test
     secrets: inherit

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,4 +1,4 @@
-# This is a Spack Environment file!!!
+# This is a Spack Environment file!!!!
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,4 +1,4 @@
-# This is a Spack Environment file.
+# This is a Spack Environment file!!
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.
@@ -29,7 +29,7 @@ spack:
   packages:
     access-test-component:
       require:
-        - '@main'
+        - '@git.main'
     openmpi:
       require:
         - '@4.1.5'

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,4 +1,4 @@
-# This is a Spack Environment file!!
+# This is a Spack Environment file!!!
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,4 +1,4 @@
-# This is a Spack Environment file!!!!
+# This is a Spack Environment file!!!!!
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.

--- a/spack.yaml
+++ b/spack.yaml
@@ -1,4 +1,4 @@
-# This is a Spack Environment file!!!!!
+# This is a Spack Environment file!!!!!!
 #
 # It describes a set of packages to be installed, along with
 # configuration settings.

--- a/spack.yaml
+++ b/spack.yaml
@@ -25,7 +25,7 @@ spack:
   #         - [$%compiler_targets]
   specs:
     # - $ROOT_SPEC
-    - access-test@git.2025.04.000
+    - access-test@git.2025.04.001
   packages:
     access-test-component:
       require:
@@ -51,4 +51,4 @@ spack:
           - access-test
           - access-test-component
         projections:
-          access-test: '{name}/2025.04.000'
+          access-test: '{name}/2025.04.001'


### PR DESCRIPTION
References ACCESS-NRI/build-cd#269

## Background

This PR is created for the purposes of testing the updated `build-cd` Release Provenance database, serviced by `tracking_services`

It uses the ephemeral `release-provenance-2.0_TEST` branch off of `build-cd`s `release-provenance-2.0` PR branch - don't merge this one, as the workflow version referred to will not exist once testing is complete!
 


---
:rocket: The latest prerelease `access-test/pr36-5` at d941e2b493af42d9b1e559a412895f1f3faf201e is here: https://github.com/ACCESS-NRI/ACCESS-TEST/pull/36#issuecomment-2843746441 :rocket:





