### PR TITLE
Add openmpi to module includes

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -50,5 +50,6 @@ spack:
         include:
           - access-test
           - access-test-component
+          - openmpi
         projections:
           access-test: '{name}/2025.06.001'

--- a/spack.yaml
+++ b/spack.yaml
@@ -32,7 +32,7 @@ spack:
         - '@main'
     openmpi:
       require:
-        - '@4.1.5'
+        - '@5.0.5'
     gcc-runtime:
       require:
         - '%gcc'


### PR DESCRIPTION
Testing what happens to the external openmpi module projection

---
:rocket: The latest prerelease `access-test/pr49-2` at 42ff28619c954e4ba2c01d435d8fd0fe4bd5bb2d is here: https://github.com/ACCESS-NRI/ACCESS-TEST/pull/49#issuecomment-3102178377 :rocket:


