### PR TITLE
spack.yaml: remove comments copied from the template

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -3,29 +3,8 @@
 # It describes a set of packages to be installed, along with
 # configuration settings.
 spack:
-  ## This section is what would be done for multi-HPC builds - see the commented reference to
-  ## $ROOT_SPEC in spack.specs below.
-  # definitions:
-  #   - ROOT_PACKAGE:
-  #       - access-test@git.2025.03.1
-  #
-  #   # Specific case for Gadi - should be run. Note the check for the environment variable first!
-  #   - when: '"DEPLOYMENT_TARGET" in env and env["DEPLOYMENT_TARGET"] == "gadi"'
-  #     compiler_targets:
-  #       - intel@2021.10.0 target=x86_64
-  #
-  #   # Example default case, should only be used outside of the CI system.
-  #   - when: '"DEPLOYMENT_TARGET" not in env'
-  #     compiler_targets:
-  #       - intel@2021.10.0 target=x86_64
-
-  #   - ROOT_SPEC:
-  #     - matrix:
-  #         - [$ROOT_PACKAGE]
-  #         - [$%compiler_targets]
   specs:
-    # - $ROOT_SPEC
-    - access-test@git.2025.06.001
+    - access-test@git.2025.09.000
   packages:
     access-test-component:
       require:
@@ -36,7 +15,6 @@ spack:
     gcc-runtime:
       require:
         - '%gcc'
-    # When using multi-HPC builds, this spack.packages.all section can be commented out.
     all:
       require:
         - '%intel@2021.10.0'


### PR DESCRIPTION
* The comments can be found in the model-deployment-template repo: https://github.com/ACCESS-NRI/model-deployment-template/blob/main/spack.yaml

---
:rocket: The latest prerelease `access-test/pr55-1` at 5a2bb71d267511b9d362542468404b3d6959dd44 is here: https://github.com/ACCESS-NRI/ACCESS-TEST/pull/55#issuecomment-3257116863 :rocket:

