### PR TITLE
TEST: Custom Scopes via `versions.json`

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,11 +10,11 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v7
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
     with:
       model: ${{ vars.NAME }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       contents: write

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
+    uses: access-nri/build-cd/.github/workflows/cd.yml@334-spack-v1-migration-config-removal-from-manifest_TEST
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,15 +19,14 @@ on:
 jobs:
   pr-ci:
     name: CI
-    if: >-
-      github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v7
+    if: github.event.action != 'closed'
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
       pr: ${{ github.event.pull_request.number }}
-      spack-manifest-schema-version: 1-0-7
-      config-versions-schema-version: 3-0-0
+      spack-manifest-schema-version: 2-0-0
+      config-versions-schema-version: 4-0-0
       config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
@@ -37,7 +36,7 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v7
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
     with:
       root-sbd: access-test
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
   pr-ci:
     name: CI
     if: github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci.yml@334-spack-v1-migration-config-removal-from-manifest_TEST
     with:
       model: ${{ vars.NAME }}
       # root-sbd: if different from vars.NAME
@@ -36,7 +36,7 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@334-spack-v1-migration-config-removal-from-manifest_TEST
     with:
       root-sbd: access-test
     secrets: inherit

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
-  "spack": "1.0",
+  "spack": "1.1",
   "access-spack-packages": "main"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "https://github.com/ACCESS-NRI/schema/blob/main/au.org.access-nri/model/deployment/config/versions/3-0-0.json",
-    "spack": "0.22",
-    "spack-packages": "main"
+  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
+  "spack": "1.0",
+  "access-spack-packages": "main"
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "api-v2"
+  "access-spack-packages": "api-v2",
+  "custom-scopes": ["ukmo-restricted-scope"]
 }

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "main"
+  "access-spack-packages": "api-v2"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -3,8 +3,12 @@
 # It describes a set of packages to be installed, along with
 # configuration settings.
 spack:
+  definitions:
+  # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
+  - _name: [access-test]
+  - _version: [2025.09.000]
   specs:
-  - access-test@git.2025.09.000
+  - access-test
   packages:
     access-test-component:
       require:

--- a/spack.yaml
+++ b/spack.yaml
@@ -4,21 +4,21 @@
 # configuration settings.
 spack:
   specs:
-    - access-test@git.2025.09.000
+  - access-test@git.2025.09.000
   packages:
     access-test-component:
       require:
-        - '@main'
+      - '@main'
     openmpi:
       require:
-        - '@4.1.5'
+      - '@4.1.5'
     gcc-runtime:
       require:
-        - '%gcc'
+      - '%gcc'
     all:
       require:
-        - '%intel@2021.10.0'
-        - 'target=x86_64'
+      - '%intel@2021.10.0'
+      - 'target=x86_64'
   view: true
   concretizer:
     unify: true

--- a/spack.yaml
+++ b/spack.yaml
@@ -18,10 +18,16 @@ spack:
       - '@4.1.5'
     gcc-runtime:
       require:
-      - '%gcc'
+      - '%access_gcc'
+
+    # Compilers
+    intel-oneapi-compilers-classic:
+      require:
+      - '@2021.10.0'
+
     all:
       require:
-      - '%intel@2021.10.0'
+      - '%access_intel'
       - 'target=x86_64'
   view: true
   concretizer:


### PR DESCRIPTION
## Background

This is a test for the new `custom-scopes` stuff, based on the `infra-v8` branch. See ACCESS-NRI/build-cd#335

## The PR

- **[no ci] infra: Update to v8**
- **[no ci] infra: Update spack version to v1.1, update manifest schema to 2-0-0**
- **[no ci] spack.yaml: Dedent list elements for spack-style manifests**
- **[no ci] spack.yaml: Add reserved definitions**
- **[no ci] spack.yaml: Use toolchains**
- **Change entrypoint workflow version to 334-spack-v1-migration-config-removal-from-manifest_TEST**


---
:rocket: The latest prerelease `access-test/pr61-5` at 7f192f898883d660ff9795facc5ed71b1174914f is here: https://github.com/ACCESS-NRI/ACCESS-TEST/pull/61#issuecomment-3765954590 :rocket:





