### PR TITLE
Test CD machinery

### DIFF
--- a/spack.yaml
+++ b/spack.yaml
@@ -15,7 +15,7 @@ spack:
       - '@main'
     openmpi:
       require:
-      - '@4.1.5'
+      - '@5.0.8'
     c:
       require:
       - 'intel-oneapi-compilers@2025.2.0'


### PR DESCRIPTION
Update openmpi version to test CD machinery

---
:rocket: The latest prerelease `access-test/pr68-1` at 2753d0b288e0683db1635b5de586189b06d01437 is here: https://github.com/ACCESS-NRI/ACCESS-TEST/pull/68#issuecomment-4394009870 :rocket:

