### PR TITLE
Change target from x86_64 to x86_64_v4

### DIFF
--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,5 @@
 {
   "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
   "spack": "1.1",
-  "access-spack-packages": "2026.02.002"
+  "access-spack-packages": "2026.05.003"
 }

--- a/spack.yaml
+++ b/spack.yaml
@@ -6,7 +6,7 @@ spack:
   definitions:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-test]
-  - _version: [2026.01.001]
+  - _version: [2026.06.000]
   specs:
   - access-test
   packages:
@@ -15,7 +15,7 @@ spack:
       - '@main'
     openmpi:
       require:
-      - '@4.1.5'
+      - '@5.0.8'
     c:
       require:
       - 'intel-oneapi-compilers@2025.2.0'
@@ -27,7 +27,7 @@ spack:
       - 'intel-oneapi-compilers@2025.2.0'
     all:
       prefer:
-      - 'target=x86_64'
+      - 'target=x86_64_v4'
   view: true
   concretizer:
     unify: true


### PR DESCRIPTION
* A number of ACCESS models have changed the target to x86_64_v4
* Spack removes the single quotes when re-writing the spack.yaml

---
:rocket: The latest prerelease `access-test/pr69-4` at 7ae11eaca028a6c990895de95e892735e2f038ac is here: https://github.com/ACCESS-NRI/ACCESS-TEST/pull/69#issuecomment-4597737967 :rocket:





