### PR TITLE
Infra Update `v9`: Consolidate Config Into Manifest

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -5,17 +5,14 @@ on:
       - main
       - backport/*.*
     paths:
-      - config/**
       - spack.yaml
 jobs:
   cd:
     name: CD
-    uses: access-nri/build-cd/.github/workflows/cd.yml@v8
+    uses: access-nri/build-cd/.github/workflows/cd.yml@v9
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0
-      config-versions-schema-version: 4-0-0
-      config-packages-schema-version: 1-0-0
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -12,7 +12,7 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/cd.yml@v9
     with:
       model: ${{ vars.NAME }}
-      spack-manifest-schema-version: 2-0-0
+      spack-manifest-schema-version: 3-0-0
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -11,7 +11,7 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/ci.yml@v9
     with:
       model: ${{ vars.NAME }}
-      spack-manifest-schema-version: 2-0-0
+      spack-manifest-schema-version: 3-0-0
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -8,12 +8,10 @@ jobs:
   redeploy:
     name: Redeploy
     if: startsWith(github.event.comment.body, '!redeploy') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v9
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0
-      config-versions-schema-version: 4-0-0
-      config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
       contents: write
@@ -22,7 +20,7 @@ jobs:
   bump:
     name: Bump
     if: startsWith(github.event.comment.body, '!bump') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci-comment.yml@v9
     with:
       model: ${{ vars.NAME }}
     permissions:
@@ -32,7 +30,7 @@ jobs:
   configs:
     name: Configs
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
-    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v9
     with:
       model: ${{ vars.NAME }}
       auto-configs-pr-schema-version: 1-0-0

--- a/.github/workflows/ci-command.yml
+++ b/.github/workflows/ci-command.yml
@@ -32,7 +32,6 @@ jobs:
     if: startsWith(github.event.comment.body, '!update-configs') && github.event.issue.pull_request
     uses: access-nri/build-cd/.github/workflows/ci-command-configs.yml@v9
     with:
-      model: ${{ vars.NAME }}
       auto-configs-pr-schema-version: 1-0-0
     permissions:
       pull-requests: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,18 +14,15 @@ on:
       - dev
       - backport/*.*
     paths:
-      - config/**
       - spack.yaml
 jobs:
   pr-ci:
     name: CI
     if: github.event.action != 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci.yml@v9
     with:
       model: ${{ vars.NAME }}
       spack-manifest-schema-version: 2-0-0
-      config-versions-schema-version: 4-0-0
-      config-packages-schema-version: 1-0-0
     permissions:
       pull-requests: write
       contents: write
@@ -34,5 +31,5 @@ jobs:
   pr-closed:
     name: Closed
     if: github.event.action == 'closed'
-    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v8
+    uses: access-nri/build-cd/.github/workflows/ci-closed.yml@v9
     secrets: inherit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     uses: access-nri/build-cd/.github/workflows/ci.yml@v9
     with:
       model: ${{ vars.NAME }}
-      spack-manifest-schema-version: 2-0-0
+      spack-manifest-schema-version: 3-0-0
     permissions:
       pull-requests: write
       contents: write

--- a/config/packages.json
+++ b/config/packages.json
@@ -1,9 +1,0 @@
-{
-  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/packages/1-0-0.json",
-  "provenance": [
-    "access-test-component"
-  ],
-  "injection": [
-    "openmpi"
-  ]
-}

--- a/config/versions.json
+++ b/config/versions.json
@@ -1,5 +1,0 @@
-{
-  "$schema": "https://raw.githubusercontent.com/ACCESS-NRI/schema/main/au.org.access-nri/model/deployment/config/versions/4-0-0.json",
-  "spack": "1.1",
-  "access-spack-packages": "2026.05.003"
-}

--- a/spack.yaml
+++ b/spack.yaml
@@ -7,6 +7,11 @@ spack:
   # _name and _version are reserved definitions that inform build-cd deployments, and have no effect otherwise
   - _name: [access-test]
   - _version: [2026.06.000]
+  # _spack-version and _custom-scopes inform the branch of spack to use, and custom scopes if applicable, respectively
+  - _spack-version: ["1.1"]
+  # Release database provenance information - packages for inclusion into the database, and packages just for injection into the modules
+  - _provenance: ["access-test-component"]
+  - _injection: ["openmpi"]
   specs:
   - access-test
   packages:
@@ -31,3 +36,8 @@ spack:
   view: true
   concretizer:
     unify: true
+  repos:
+    access_spack_packages:
+      git: https://github.com/ACCESS-NRI/access-spack-packages.git
+      tag: 2026.05.003
+      destination: $env/.package_repos/access-spack-packages


### PR DESCRIPTION
Closes #74

References ACCESS-NRI/build-cd#404

> [!IMPORTANT]
> This is a major update to the deployment infrastructure. Open PRs should be rebased once this is merged.

## Background

We have moved to `spack v1.1`, which has a bunch of cool features that allow us to take a bit of strain off the infrastructure by letting spack handle things like cloning git-based spack package repositories as opposed to the infra having to do it. 
While we were at it, we moved as much of the `config/*.json` files into the manifest as Reserved Definitions (`spack.definitions` that have a `_` prepended, like `_name` and `_version`), just so it was all in the one file. 
Finally, I have removed a unnneeded `model` input from the `!update-configs` entrypoint workflow, so it's a bit cleaner.
## What you 🫵 need to know

* You now specify the `access-spack-packages` version in the `spack.yaml`, under the `spack.repos.access_spack_packages` key, giving it either a `commit:`, `branch:` or `tag:`. Keep the `destination:` as it is - it will aid the infra in cleanup after!
* Similarly, you now specify the spack version, custom scopes, packages for provenance and packages for injection as reserved definitions at the top of the `spack.yaml` file. 

## The PR

* Bump entrypoint workflows to `v9`, remove unneeded inputs, updated `spack.yaml` schema version
* Move config from `config/` into `spack.yaml`s, delete those files

